### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,19 +12,19 @@ Ephemeris	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setLocationOnEarth                               KEYWORD2
-setLocationOnEarth                               KEYWORD2
-setAltitude                                      KEYWORD2
+setLocationOnEarth	KEYWORD2
+setLocationOnEarth	KEYWORD2
+setAltitude	KEYWORD2
 
-floatingHoursToHoursMinutesSeconds               KEYWORD2
-hoursMinutesSecondsToFloatingHours               KEYWORD2
-floatingDegreesToDegreesMinutesSeconds           KEYWORD2
-degreesMinutesSecondsToFloatingDegrees           KEYWORD2
+floatingHoursToHoursMinutesSeconds	KEYWORD2
+hoursMinutesSecondsToFloatingHours	KEYWORD2
+floatingDegreesToDegreesMinutesSeconds	KEYWORD2
+degreesMinutesSecondsToFloatingDegrees	KEYWORD2
 
-equatorialToHorizontalCoordinatesAtDateAndTime   KEYWORD2
-horizontalToEquatorialCoordinatesAtDateAndTime   KEYWORD2
-solarSystemObjectAtDateAndTime                   KEYWORD2
-riseAndSetForEquatorialCoordinatesAtDateAndTime  KEYWORD2
+equatorialToHorizontalCoordinatesAtDateAndTime	KEYWORD2
+horizontalToEquatorialCoordinatesAtDateAndTime	KEYWORD2
+solarSystemObjectAtDateAndTime	KEYWORD2
+riseAndSetForEquatorialCoordinatesAtDateAndTime	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords